### PR TITLE
synced timeout to wall clock

### DIFF
--- a/lib/atom-clock-view.coffee
+++ b/lib/atom-clock-view.coffee
@@ -11,7 +11,6 @@ class AtomClockView extends View
   showIncon: false
   refreshInterval: 0
 
-  runner: null
   statusBar: null
 
   @content: () ->
@@ -46,10 +45,11 @@ class AtomClockView extends View
 
   startTicker: ->
     @setDate()
-    @runner = setInterval @setDate, @refreshInterval
+    @tick = setTimeout (=> @startTicker()), 
+                @refreshInterval - (Date.now() % @refreshInterval)
 
   clearTicker: ->
-    clearInterval(@runner) unless not @runner
+    if @tick then clearTimeout(@tick); @tick = null
 
   refreshTicker: =>
     @setConfigValues()

--- a/lib/atom-clock-view.coffee
+++ b/lib/atom-clock-view.coffee
@@ -49,7 +49,7 @@ class AtomClockView extends View
                 @refreshInterval - (Date.now() % @refreshInterval)
 
   clearTicker: ->
-    if @tick then clearTimeout(@tick); @tick = null
+    clearTimeout(@tick) unless not @tick
 
   refreshTicker: =>
     @setConfigValues()


### PR DESCRIPTION
I changed the setInterval to setTimeout with a proper timeout value.

My atom-clock changed immediately when my phone and laptop changed.  Actually, it changed a bit earlier than the laptop, which is hard to understand.  The chromebook code for the task bar is apparently worse than mine.  (grin)

This is only tested for 60 seconds, 50 seconds, and one second.  It will still function for odd times like 50 seconds as well as the old setInterval method, but that doesn't make much sense.  Maybe the interval config should be changed to a selection of 1 sec or 60 secs and a setInterval would run for 1 sec and setTimeout for 60.


