### PR TITLE
Rewrite draw routines to match how Atom's standard status bar elements are displayed.

### DIFF
--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -44,8 +44,12 @@ export default class AtomClockView {
 
   drawElement() {
     this.element = document.createElement('div')
-    this.element.className = 'atom-clock'
-    this.element.appendChild(document.createElement('span'))
+    this.element.className = 'atom-clock inline-block'
+
+    var timeEl = document.createElement('span');
+    timeEl.className = 'atom-clock-label';
+
+    this.element.appendChild(timeEl);
 
     this.statusBar.addRightTile({
       item: this.element,
@@ -79,7 +83,7 @@ export default class AtomClockView {
 
   setDate() {
     this.date = this.getDate(this.locale, this.dateFormat)
-    this.element.firstChild.textContent = this.date
+    this.element.querySelector(".atom-clock-label").textContent = this.date
   }
 
   getDate(locale, format) {
@@ -90,10 +94,14 @@ export default class AtomClockView {
   }
 
   setIcon(toSet) {
-    if (toSet)
-      this.element.firstChild.className += 'icon icon-clock'
-    else
-      this.element.firstChild.className = ''
+    if (toSet) {
+      var iconEl = document.createElement('span')
+      iconEl.className = 'icon icon-clock'
+
+      this.element.insertBefore(iconEl, this.element.firstChild)
+    } else {
+      this.element.removeChild(this.element.querySelector(".icon-clock"))
+    }
   }
 
   toggle() {

--- a/styles/atom-clock.less
+++ b/styles/atom-clock.less
@@ -1,13 +1,5 @@
 @import "ui-variables";
 
-.atom-clock {
-  display: inline-block;
-  margin-left: 1em;
-  margin-right: 0.5em;
-  position: relative;
-  vertical-align: middle;
-
-  .span {
-    text-align: left;
-  }
+.atom-clock-label {
+  text-align: left;
 }


### PR DESCRIPTION
**Before**

![screen shot 2017-04-27 at 10 42 30 pm](https://cloud.githubusercontent.com/assets/753919/25515652/df0b174a-2b9a-11e7-9933-b03e53ffbbd8.png)

**After** 

![screen shot 2017-04-27 at 10 47 31 pm](https://cloud.githubusercontent.com/assets/753919/25515748/8688a280-2b9b-11e7-8979-91a483a0c73b.png)



