### PR TITLE
Added a customisable tooltip to the clock to display another time format on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ The clock can be installed through Atom. Alternatively, you can use `apm`:
 
 ### Settings
 
-##### Date format
-It specifies the format to use when displaying the date. The package uses `moment.js` to format the time, so please refer to the related [`moment.js` documentation](http://momentjs.com/docs/#/displaying/format/). The default value for the date format is `H:mm`.
+##### Time format
+It specifies the format to use when displaying the time. The package uses `moment.js` to format the time, so please refer to the related [`moment.js` documentation](http://momentjs.com/docs/#/displaying/format/). The default value for the time format is `H:mm`.
+
+#### Tooltip
+If enabled, a tooltip will be shown when you hover over the time in the status bar to display the time in an alternate format. By default the tooltip is disabled, and the format is `LLLL`.
 
 ##### Locale
 It specifies the locale the clock will use when displaying the time. Its default value is `en`. Please check the [`moment.js` locale folder](https://github.com/moment/moment/tree/master/locale) for a complete list of all supported locales.

--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -109,17 +109,15 @@ export default class AtomClockView {
   }
 
   setTooltip(toSet) {
-    if (this.tooltip === undefined) {
+    if (this.tooltip === undefined)
       this.tooltip = atom.tooltips.add(this.element, {
         title: () => this.getDate(this.locale, this.tooltipDateFormat)
       })
-    }
 
-    if (toSet) {
+    if (toSet)
       atom.tooltips.findTooltips(this.element)[0].enable()
-    } else {
+    else
       atom.tooltips.findTooltips(this.element)[0].disable()
-    }
   }
 
   toggle() {
@@ -133,5 +131,4 @@ export default class AtomClockView {
     this.tooltip.dispose()
     this.element.parentNode.removeChild(this.element)
   }
-
 }

--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -16,6 +16,7 @@ export default class AtomClockView {
 
   initialize() {
     this.setConfigValues()
+    this.setTooltip(this.showTooltip)
     this.setIcon(this.showIcon)
     this.startTicker()
 
@@ -24,6 +25,15 @@ export default class AtomClockView {
     }))
 
     this.subscriptions.add(atom.config.onDidChange('atom-clock.dateFormat', () => {
+      this.refreshTicker()
+    }))
+
+    this.subscriptions.add(atom.config.onDidChange('atom-clock.showTooltip', () => {
+      this.setConfigValues()
+      this.setTooltip(this.showTooltip)
+    }))
+
+    this.subscriptions.add(atom.config.onDidChange('atom-clock.tooltipDateFormat', () => {
       this.refreshTicker()
     }))
 
@@ -55,6 +65,8 @@ export default class AtomClockView {
 
   setConfigValues() {
     this.dateFormat = atom.config.get('atom-clock.dateFormat')
+    this.showTooltip = atom.config.get('atom-clock.showTooltip')
+    this.tooltipDateFormat = atom.config.get('atom-clock.tooltipDateFormat')
     this.locale = atom.config.get('atom-clock.locale')
     this.refreshInterval = atom.config.get('atom-clock.refreshInterval') * 1000
     this.showIcon = atom.config.get('atom-clock.showClockIcon')
@@ -96,6 +108,20 @@ export default class AtomClockView {
       this.element.firstChild.className = ''
   }
 
+  setTooltip(toSet) {
+    if (this.tooltip === undefined) {
+      this.tooltip = atom.tooltips.add(this.element, {
+        title: () => this.getDate(this.locale, this.tooltipDateFormat)
+      })
+    }
+
+    if (toSet) {
+      atom.tooltips.findTooltips(this.element)[0].enable()
+    } else {
+      atom.tooltips.findTooltips(this.element)[0].disable()
+    }
+  }
+
   toggle() {
     var style = this.element.style.display
     this.element.style.display = style === 'none' ? '' : 'none'
@@ -104,6 +130,7 @@ export default class AtomClockView {
   destroy() {
     this.clearTicker()
     this.subscriptions.dispose()
+    this.tooltip.dispose()
     this.element.parentNode.removeChild(this.element)
   }
 

--- a/lib/atom-clock.js
+++ b/lib/atom-clock.js
@@ -11,25 +11,37 @@ export default {
       description: 'Specify the time format. [Here](http://momentjs.com/docs/#/displaying/format/) you can find all the available formats.',
       default: 'H:mm',
       order: 1
+    }, showTooltip: {
+      type: 'boolean',
+      title: 'Enable tooltip',
+      description: 'Enables a customisable tooltip when you hover over the time',
+      default: false,
+      order: 2
+    }, tooltipDateFormat: {
+      type: 'string',
+      title: 'Tooltip time format',
+      description: 'Specify the time format in the tooltip. [Here](http://momentjs.com/docs/#/displaying/format/) you can find all the available formats.',
+      default: 'LLLL',
+      order: 3
     }, locale: {
       type: 'string',
       title: 'Locale',
       description: 'Specify the time locale. [Here](https://github.com/moment/moment/tree/master/locale) you can find all the available locales.',
       default: 'en',
-      order: 2
+      order: 4
     }, refreshInterval: {
       type: 'integer',
       title: 'Clock interval',
       description: 'Specify the refresh interval (in seconds) for the plugin to evaluate the date.',
       default: 60,
       minimum: 1,
-      order: 3
+      order: 5
     }, showClockIcon: {
       type: 'boolean',
       title: 'Icon clock',
       description: 'Show clock icon in the status bar?',
       default: false,
-      order: 4
+      order: 6
     }
   },
 

--- a/spec/atom-clock-spec.js
+++ b/spec/atom-clock-spec.js
@@ -27,6 +27,8 @@ describe('Atom Clock', () => {
     expect(AtomClock.atomClockView.element).toBeDefined()
 
     expect(AtomClock.config.dateFormat.default).toBe('H:mm')
+    expect(AtomClock.config.showTooltip.default).toBe(false)
+    expect(AtomClock.config.tooltipDateFormat.default).toBe('LLLL')
     expect(AtomClock.config.locale.default).toBe('en')
     expect(AtomClock.config.refreshInterval.default).toBe(60)
     expect(AtomClock.config.showClockIcon.default).toBe(false)
@@ -39,11 +41,25 @@ describe('Atom Clock', () => {
     expect(AtomClock.atomClockView.refreshTicker).toHaveBeenCalled()
   })
 
+  it('should refresh the ticker when the tooltip date format is changed', () => {
+    spyOn(AtomClock.atomClockView, 'refreshTicker')
+
+    atom.config.set('atom-clock.tooltipDateFormat', 'H')
+    expect(AtomClock.atomClockView.refreshTicker).toHaveBeenCalled()
+  })
+
   it('should refresh the ticker when the interval is changed', () => {
     spyOn(AtomClock.atomClockView, 'refreshTicker')
 
     atom.config.set('atom-clock.refreshInterval', '20')
     expect(AtomClock.atomClockView.refreshTicker).toHaveBeenCalled()
+  })
+
+  it('should set the configuration values when the tooltip is enabled', () => {
+    spyOn(AtomClock.atomClockView, 'setConfigValues')
+
+    atom.config.set('atom-clock.showTooltip', true)
+    expect(AtomClock.atomClockView.setConfigValues).toHaveBeenCalled()
   })
 
   it('should set the configuration values when clock icon is requested', () => {

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -66,7 +66,6 @@ describe('Atom Clock', () => {
   })
 
   it('should show the time in the tooltip with the default format', () => {
-    atom.config.set('atom-clock.showTooltip', true)
     date = getTooltipDate(workspaceElement)
     expect(date.toLowerCase()).toBe('saturday, april 11, 1987 4:00 am')
   })
@@ -82,15 +81,11 @@ describe('Atom Clock', () => {
   })
 
   it('should change the format of the displayed time in the tooltip', () => {
-    atom.config.set('atom-clock.showTooltip', true)
-
     atom.config.set('atom-clock.tooltipDateFormat', 'H:mm:ss')
-    tooltip = getTooltips(workspaceElement)[0]
     date = getTooltipDate(workspaceElement)
     expect(date).toBe('4:00:00')
 
     atom.config.set('atom-clock.tooltipDateFormat', 'DD dddd YY H:mm')
-    tooltip = getTooltips(workspaceElement)[0]
     date = getTooltipDate(workspaceElement)
     expect(date.toLowerCase()).toBe('11 saturday 87 4:00')
   })

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -2,6 +2,16 @@
 
 MockDate = require('mockdate')
 
+getTooltips = function(workspaceElement) {
+  element = workspaceElement.querySelector('.atom-clock')
+  return atom.tooltips.findTooltips(element)
+}
+
+getTooltipDate = function(workspaceElement) {
+  tooltip = getTooltips(workspaceElement)[0]
+  return tooltip.getTitle()
+}
+
 describe('Atom Clock', () => {
 
   let workspaceElement
@@ -30,6 +40,15 @@ describe('Atom Clock', () => {
     MockDate.reset()
   })
 
+  it('should not show the tooltip by default', () => {
+    expect(getTooltips(workspaceElement)[0].enabled).toBe(false)
+  })
+
+  it('should show the tooltip when configured', () => {
+    atom.config.set('atom-clock.showTooltip', true)
+    expect(getTooltips(workspaceElement)[0].enabled).toBe(true)
+  })
+
   it('should not show the clock icon by default', () => {
     icon = workspaceElement.querySelector('.atom-clock > .icon-clock')
     expect(icon).toBeNull()
@@ -46,6 +65,12 @@ describe('Atom Clock', () => {
     expect(date).toBe('4:00')
   })
 
+  it('should show the time in the tooltip with the default format', () => {
+    atom.config.set('atom-clock.showTooltip', true)
+    date = getTooltipDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('saturday, april 11, 1987 4:00 am')
+  })
+
   it('should change the format of displayed time', () => {
     atom.config.set('atom-clock.dateFormat', 'H:mm:ss')
     date = workspaceElement.querySelector('.atom-clock > span').innerText
@@ -56,10 +81,31 @@ describe('Atom Clock', () => {
     expect(date.toLowerCase()).toBe('11 saturday 87 4:00')
   })
 
+  it('should change the format of the displayed time in the tooltip', () => {
+    atom.config.set('atom-clock.showTooltip', true)
+
+    atom.config.set('atom-clock.tooltipDateFormat', 'H:mm:ss')
+    tooltip = getTooltips(workspaceElement)[0]
+    date = getTooltipDate(workspaceElement)
+    expect(date).toBe('4:00:00')
+
+    atom.config.set('atom-clock.tooltipDateFormat', 'DD dddd YY H:mm')
+    tooltip = getTooltips(workspaceElement)[0]
+    date = getTooltipDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('11 saturday 87 4:00')
+  })
+
   it('should change the clock content according with the locale', () => {
     atom.config.set('atom-clock.dateFormat', 'DD dddd YY H:mm')
     atom.config.set('atom-clock.locale', 'it')
     date = workspaceElement.querySelector('.atom-clock > span').innerText
+    expect(date.toLowerCase()).toBe('11 sabato 87 4:00')
+  })
+
+  it('should change the clock content in the tooltip according with the locale', () => {
+    atom.config.set('atom-clock.tooltipDateFormat', 'DD dddd YY H:mm')
+    atom.config.set('atom-clock.locale', 'it')
+    date = getTooltipDate(workspaceElement)
     expect(date.toLowerCase()).toBe('11 sabato 87 4:00')
   })
 


### PR DESCRIPTION
Inspired by #26, this adds a tooltip to the clock to display the time in an alternate format. The tooltip is disabled by default and can be enabled in the settings as can be seen in the images. Specs have been written, I aimed to make them as similar as the existing specs as possible as well as trying to adhere to the established code style.

![screen shot 2017-05-26 at 12 48 45](https://cloud.githubusercontent.com/assets/3003251/26497512/b69eac00-4223-11e7-9ba9-3a47ac9bf7dc.png)

![screen shot 2017-05-26 at 12 49 03](https://cloud.githubusercontent.com/assets/3003251/26497515/ba62aada-4223-11e7-816a-9dd1f854cdbf.png)
