### PR TITLE
Updated .travis.yml to be the same as atom/ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ os:
   - linux
   - osx
 
-sudo: false
 dist: trusty
 
 ### Generic setup follows ###
@@ -39,9 +38,10 @@ sudo: false
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
-    - libsecret-1-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
.travis.yml was updated in [atom/ci](https://github.com/atom/ci/commit/4eb2c949b885c1743d761eff6a6b0e8e3de073d3) seemingly to fix the new Linux Beta issue referenced in #33