### PR TITLE
Added an option to display UTC time instead of local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ If enabled, a tooltip will be shown when you hover over the time in the status b
 ##### Locale
 It specifies the locale the clock will use when displaying the time. Its default value is `en`. Please check the [`moment.js` locale folder](https://github.com/moment/moment/tree/master/locale) for a complete list of all supported locales.
 
+##### UTC
+If enabled, both the status bar clock and tooltip clock (if enabled) will display UTC time instead of local time.
+
 ##### Clock interval
 It specifies how many seconds should run between two time updates, and it is defaulted to 60 (one update per minute).
 

--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -41,6 +41,10 @@ export default class AtomClockView {
       this.refreshTicker()
     }))
 
+    this.subscriptions.add(atom.config.onDidChange('atom-clock.showUTC', () => {
+      this.refreshTicker()
+    }))
+
     this.subscriptions.add(atom.config.onDidChange('atom-clock.refreshInterval', () => {
       this.refreshTicker()
     }))
@@ -76,6 +80,7 @@ export default class AtomClockView {
     this.showTooltip = atom.config.get('atom-clock.showTooltip')
     this.tooltipDateFormat = atom.config.get('atom-clock.tooltipDateFormat')
     this.locale = atom.config.get('atom-clock.locale')
+    this.showUTC = atom.config.get('atom-clock.showUTC')
     this.refreshInterval = atom.config.get('atom-clock.refreshInterval') * 1000
     this.showIcon = atom.config.get('atom-clock.showClockIcon')
   }
@@ -106,7 +111,12 @@ export default class AtomClockView {
     if (!this.Moment)
       this.Moment = require('moment')
 
-    return this.Moment().locale(locale).format(format)
+    var moment = this.Moment().locale(locale)
+
+    if (this.showUTC)
+      moment.utc()
+
+    return moment.format(format)
   }
 
   setIcon(toSet) {

--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -21,7 +21,8 @@ export default class AtomClockView {
     this.startTicker()
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'atom-clock:toggle': () => this.toggle()
+      'atom-clock:toggle': () => this.toggle(),
+      'atom-clock:utc-mode': () => atom.config.set('atom-clock.showUTC', !this.showUTC)
     }))
 
     this.subscriptions.add(atom.config.onDidChange('atom-clock.dateFormat', () => {

--- a/lib/atom-clock.js
+++ b/lib/atom-clock.js
@@ -29,19 +29,25 @@ export default {
       description: 'Specify the time locale. [Here](https://github.com/moment/moment/tree/master/locale) you can find all the available locales.',
       default: 'en',
       order: 4
+    }, showUTC: {
+      type: 'boolean',
+      title: 'Display UTC time',
+      description: 'Use UTC to display the time instead of local time',
+      default: false,
+      order: 5
     }, refreshInterval: {
       type: 'integer',
       title: 'Clock interval',
       description: 'Specify the refresh interval (in seconds) for the plugin to evaluate the date.',
       default: 60,
       minimum: 1,
-      order: 5
+      order: 6
     }, showClockIcon: {
       type: 'boolean',
       title: 'Icon clock',
       description: 'Show clock icon in the status bar?',
       default: false,
-      order: 6
+      order: 7
     }
   },
 

--- a/menus/atom-clock.cson
+++ b/menus/atom-clock.cson
@@ -7,6 +7,10 @@
         {
           'label': 'Toggle clock in status bar'
           'command': 'atom-clock:toggle'
+        },
+        {
+          'label': 'Toggle UTC mode'
+          'command': 'atom-clock:utc-mode'
         }
       ]
     ]

--- a/spec/atom-clock-spec.js
+++ b/spec/atom-clock-spec.js
@@ -30,6 +30,7 @@ describe('Atom Clock', () => {
     expect(AtomClock.config.showTooltip.default).toBe(false)
     expect(AtomClock.config.tooltipDateFormat.default).toBe('LLLL')
     expect(AtomClock.config.locale.default).toBe('en')
+    expect(AtomClock.config.showUTC.default).toBe(false)
     expect(AtomClock.config.refreshInterval.default).toBe(60)
     expect(AtomClock.config.showClockIcon.default).toBe(false)
   })
@@ -45,6 +46,13 @@ describe('Atom Clock', () => {
     spyOn(AtomClock.atomClockView, 'refreshTicker')
 
     atom.config.set('atom-clock.tooltipDateFormat', 'H')
+    expect(AtomClock.atomClockView.refreshTicker).toHaveBeenCalled()
+  })
+
+  it('should refresh the ticker when the UTC display setting is changed', () => {
+    spyOn(AtomClock.atomClockView, 'refreshTicker')
+
+    atom.config.set('atom-clock.showUTC', true)
     expect(AtomClock.atomClockView.refreshTicker).toHaveBeenCalled()
   })
 

--- a/spec/atom-clock-spec.js
+++ b/spec/atom-clock-spec.js
@@ -17,7 +17,6 @@ describe('Atom Clock', () => {
 
     waitsForPromise(() => atom.packages.activatePackage('atom-clock').then((clk) => {
       AtomClock = clk.mainModule
-      AtomClock.consumeStatusBar(statusBar)
     }))
 
     waitsForPromise(() => atom.workspace.open())
@@ -94,4 +93,11 @@ describe('Atom Clock', () => {
     expect(AtomClock.atomClockView.element.style.display).toBe('')
   })
 
+  it('should toggle UTC mode when toggled', () => {
+    atom.commands.dispatch(document.querySelector('atom-workspace'), 'atom-clock:utc-mode')
+    expect(AtomClock.atomClockView.showUTC).toBe(true)
+
+    atom.commands.dispatch(document.querySelector('atom-workspace'), 'atom-clock:utc-mode')
+    expect(AtomClock.atomClockView.showUTC).toBe(false)
+  })
 })

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -23,7 +23,7 @@ describe('Atom Clock', () => {
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
-    MockDate.set('1987-04-11 04:00', 60)
+    MockDate.set('1987-04-11 04:00 +0100', -60)
 
     let statusBar
     let AtomClock
@@ -113,7 +113,7 @@ describe('Atom Clock', () => {
 
     atom.config.set('atom-clock.showUTC', false)
     date = getDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 -0100')
+    expect(date.toLowerCase()).toBe('4 +0100')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getDate(workspaceElement)
@@ -125,7 +125,7 @@ describe('Atom Clock', () => {
 
     atom.config.set('atom-clock.showUTC', false)
     date = getTooltipDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 -0100')
+    expect(date.toLowerCase()).toBe('4 +0100')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getTooltipDate(workspaceElement)

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -23,7 +23,7 @@ describe('Atom Clock', () => {
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
-    MockDate.set('1987-04-11 04:00')
+    MockDate.set('1987-04-11 04:00 +0100')
 
     let statusBar
     let AtomClock
@@ -106,6 +106,30 @@ describe('Atom Clock', () => {
     atom.config.set('atom-clock.locale', 'it')
     date = getTooltipDate(workspaceElement)
     expect(date.toLowerCase()).toBe('11 sabato 87 4:00')
+  })
+
+  it('should change the whether UTC time is displayed', () => {
+    atom.config.set('atom-clock.dateFormat', 'H ZZ')
+
+    atom.config.set('atom-clock.showUTC', false)
+    date = getDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('4 +0100')
+
+    atom.config.set('atom-clock.showUTC', true)
+    date = getDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('3 +0000')
+  })
+
+  it('should change the whether UTC time is displayed in the tooltip', () => {
+    atom.config.set('atom-clock.tooltipDateFormat', 'H ZZ')
+
+    atom.config.set('atom-clock.showUTC', false)
+    date = getTooltipDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('4 +0100')
+
+    atom.config.set('atom-clock.showUTC', true)
+    date = getTooltipDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('3 +0000')
   })
 
 })

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -23,7 +23,7 @@ describe('Atom Clock', () => {
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
-    MockDate.set('1987-04-11 04:00 +0100')
+    MockDate.set('1987-04-11 04:00', 60)
 
     let statusBar
     let AtomClock
@@ -113,7 +113,7 @@ describe('Atom Clock', () => {
 
     atom.config.set('atom-clock.showUTC', false)
     date = getDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 +0100')
+    expect(date.toLowerCase()).toBe('4 -0100')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getDate(workspaceElement)
@@ -125,7 +125,7 @@ describe('Atom Clock', () => {
 
     atom.config.set('atom-clock.showUTC', false)
     date = getTooltipDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 +0100')
+    expect(date.toLowerCase()).toBe('4 -0100')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getTooltipDate(workspaceElement)

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -23,7 +23,7 @@ describe('Atom Clock', () => {
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
-    MockDate.set('1987-04-11 04:00 +0100', -60)
+    MockDate.set('1987-04-11 04:00')
 
     let statusBar
     let AtomClock
@@ -109,27 +109,19 @@ describe('Atom Clock', () => {
   })
 
   it('should change the whether UTC time is displayed', () => {
-    atom.config.set('atom-clock.dateFormat', 'H ZZ')
-
-    atom.config.set('atom-clock.showUTC', false)
-    date = getDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 +0100')
+    atom.config.set('atom-clock.dateFormat', 'ZZ')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('3 +0000')
+    expect(date.toLowerCase()).toBe('+0000')
   })
 
   it('should change the whether UTC time is displayed in the tooltip', () => {
-    atom.config.set('atom-clock.tooltipDateFormat', 'H ZZ')
-
-    atom.config.set('atom-clock.showUTC', false)
-    date = getTooltipDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('4 +0100')
+    atom.config.set('atom-clock.tooltipDateFormat', 'ZZ')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getTooltipDate(workspaceElement)
-    expect(date.toLowerCase()).toBe('3 +0000')
+    expect(date.toLowerCase()).toBe('+0000')
   })
 
 })

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -23,7 +23,7 @@ describe('Atom Clock', () => {
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
-    MockDate.set('1987-04-11 04:00')
+    MockDate.set('1987-04-11 04:00', -300)
 
     let statusBar
     let AtomClock
@@ -111,6 +111,10 @@ describe('Atom Clock', () => {
   it('should change the whether UTC time is displayed', () => {
     atom.config.set('atom-clock.dateFormat', 'ZZ')
 
+    atom.config.set('atom-clock.showUTC', false)
+    date = getDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('+0500')
+
     atom.config.set('atom-clock.showUTC', true)
     date = getDate(workspaceElement)
     expect(date.toLowerCase()).toBe('+0000')
@@ -118,6 +122,10 @@ describe('Atom Clock', () => {
 
   it('should change the whether UTC time is displayed in the tooltip', () => {
     atom.config.set('atom-clock.tooltipDateFormat', 'ZZ')
+
+    atom.config.set('atom-clock.showUTC', false)
+    date = getTooltipDate(workspaceElement)
+    expect(date.toLowerCase()).toBe('+0500')
 
     atom.config.set('atom-clock.showUTC', true)
     date = getTooltipDate(workspaceElement)


### PR DESCRIPTION
As [put forward](https://github.com/b3by/atom-clock/issues/30#issuecomment-313180414) by @gwax in #30, this adds an option to display the time as UTC time instead of local time. I've included some specs as well as the actual functionality

![screen shot 2017-07-05 at 20 07 13](https://user-images.githubusercontent.com/3003251/27880650-9a41cc5e-61bd-11e7-823e-ecc689883e1d.png)
![screen shot 2017-07-05 at 20 07 21](https://user-images.githubusercontent.com/3003251/27880651-9b20b720-61bd-11e7-9386-e747a6f51b1d.png)

