### PR TITLE
Added a class to the tooltip so it can be styled

### DIFF
--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -130,7 +130,8 @@ export default class AtomClockView {
   setTooltip(toSet) {
     if (this.tooltip === undefined)
       this.tooltip = atom.tooltips.add(this.element, {
-        title: () => this.getDate(this.locale, this.tooltipDateFormat)
+        title: () => this.getDate(this.locale, this.tooltipDateFormat),
+        class: 'atom-clock-tooltip'
       })
 
     if (toSet)


### PR DESCRIPTION
As [suggested](https://github.com/b3by/atom-clock/issues/35#issuecomment-325645421) by @JorgeDam, this adds the class `atom-clock-tooltip` to the tooltip so the text can be customised as seen below:

```css
.atom-clock-tooltip > .tooltip-inner {
  color: red;
  font-family: "Comic Sans MS";
  font-size: 2rem;
}
```

![screen shot 2017-08-29 at 17 10 32](https://user-images.githubusercontent.com/3003251/29831443-19a0c56e-8cdd-11e7-91e7-bfa9895a9d68.png)

