### PR TITLE
Adds atom-clock-utc class to the clock and tooltip when UTC is enabled

### DIFF
--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -18,6 +18,7 @@ export default class AtomClockView {
     this.setConfigValues()
     this.setTooltip(this.showTooltip)
     this.setIcon(this.showIcon)
+    this.setUTCClass(this.showUTC)
     this.startTicker()
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
@@ -44,6 +45,7 @@ export default class AtomClockView {
 
     this.subscriptions.add(atom.config.onDidChange('atom-clock.showUTC', () => {
       this.refreshTicker()
+      this.setUTCClass(this.showUTC)
     }))
 
     this.subscriptions.add(atom.config.onDidChange('atom-clock.refreshInterval', () => {
@@ -139,6 +141,17 @@ export default class AtomClockView {
     else
       atom.tooltips.findTooltips(this.element)[0].disable()
   }
+
+  setUTCClass(toSet) {
+    if (toSet) {
+      this.element.classList.add('atom-clock-utc')
+      atom.tooltips.findTooltips(this.element)[0].getTooltipElement().classList.add('atom-clock-utc')
+    } else {
+      this.element.classList.remove('atom-clock-utc')
+      atom.tooltips.findTooltips(this.element)[0].getTooltipElement().classList.remove('atom-clock-utc')
+    }
+  }
+
 
   toggle() {
     var style = this.element.style.display

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -132,4 +132,18 @@ describe('Atom Clock', () => {
     expect(date.toLowerCase()).toBe('+0000')
   })
 
+  it('should add atom-clock-utc class to the time when UTC is enabled', () => {
+    expect(workspaceElement.querySelector('.atom-clock.atom-clock-utc')).not.toExist()
+
+    atom.config.set('atom-clock.showUTC', true)
+    expect(workspaceElement.querySelector('.atom-clock.atom-clock-utc')).toExist()
+  })
+
+  it('should add atom-clock-utc class to the tooltip when UTC is enabled', () => {
+    expect(getTooltips(workspaceElement)[0].getTooltipElement().classList.contains('atom-clock-utc')).toBe(false)
+
+    atom.config.set('atom-clock.showUTC', true)
+    expect(getTooltips(workspaceElement)[0].getTooltipElement().classList.contains('atom-clock-utc')).toBe(true)
+  })
+
 })


### PR DESCRIPTION
As suggested in #42, this adds the `.atom-clock-utc` class to main atom-clock element (`.atom-clock`) and to the tooltip (`.atom-clock-tooltip`) allowing them to be styled differently if UTC mode is enabled.

![utc](https://user-images.githubusercontent.com/3003251/29879103-0e33c1b2-8d9c-11e7-8b65-13bb811df9f2.gif)

This also contains some specs to test if the class is added correctly.