### PR TITLE
Implement a a time offset option

### DIFF
--- a/lib/atom-clock-view.js
+++ b/lib/atom-clock-view.js
@@ -48,6 +48,10 @@ export default class AtomClockView {
       this.setUTCClass(this.showUTC)
     }))
 
+    this.subscriptions.add(atom.config.onDidChange('atom-clock.timeOffset', () => {
+      this.refreshTicker()
+    }))
+
     this.subscriptions.add(atom.config.onDidChange('atom-clock.refreshInterval', () => {
       this.refreshTicker()
     }))
@@ -94,6 +98,7 @@ export default class AtomClockView {
     this.tooltipDateFormat = atom.config.get('atom-clock.tooltipDateFormat')
     this.locale = atom.config.get('atom-clock.locale')
     this.showUTC = atom.config.get('atom-clock.showUTC')
+    this.timeOffset = atom.config.get('atom-clock.timeOffset')
     this.refreshInterval = atom.config.get('atom-clock.refreshInterval') * 1000
     this.showIcon = atom.config.get('atom-clock.showClockIcon')
     this.showOnlyInFullscreen = atom.config.get('atom-clock.showOnlyInFullscreen')
@@ -130,7 +135,7 @@ export default class AtomClockView {
     if (this.showUTC)
       moment.utc()
 
-    return moment.format(format)
+    return moment.add(this.timeOffset, 'm').format(format)
   }
 
   setIcon(toSet) {

--- a/lib/atom-clock.js
+++ b/lib/atom-clock.js
@@ -42,18 +42,24 @@ export default {
       description: 'Use UTC to display the time instead of local time.',
       default: false,
       order: 6
+    }, timeOffset: {
+      type: 'number',
+      title: 'Time offset',
+      description: 'Offset currently displayed time by the desired value (in minutes).',
+      default: 0,
+      order: 7
     }, showClockIcon: {
       type: 'boolean',
       title: 'Icon clock',
       description: 'Show a clock icon next to the time in the status bar.',
       default: false,
-      order: 7
+      order: 8
     }, showOnlyInFullscreen: {
       type: 'boolean',
       title: 'Full-screen only',
       description: 'Only show the clock when in full-screen.',
       default: false,
-      order: 8
+      order: 9
     }
   },
 

--- a/spec/atom-clock-spec.js
+++ b/spec/atom-clock-spec.js
@@ -30,6 +30,7 @@ describe('Atom Clock', () => {
     expect(AtomClock.config.tooltipDateFormat.default).toBe('LLLL')
     expect(AtomClock.config.locale.default).toBe('en')
     expect(AtomClock.config.showUTC.default).toBe(false)
+    expect(AtomClock.config.timeOffset.default).toBe(0)
     expect(AtomClock.config.refreshInterval.default).toBe(60)
     expect(AtomClock.config.showClockIcon.default).toBe(false)
   })

--- a/spec/atom-clock-view-spec.js
+++ b/spec/atom-clock-view-spec.js
@@ -146,4 +146,18 @@ describe('Atom Clock', () => {
     expect(getTooltips(workspaceElement)[0].getTooltipElement().classList.contains('atom-clock-utc')).toBe(true)
   })
 
+  it('should change the clock content according to the time offset', () => {
+	atom.config.set('atom-clock.timeOffset', 0)
+	date = getDate(workspaceElement)
+    expect(date).toBe('4:00')
+
+    atom.config.set('atom-clock.timeOffset', 60)
+	date = getDate(workspaceElement)
+    expect(date).toBe('5:00')
+
+    atom.config.set('atom-clock.timeOffset', 90)
+	date = getDate(workspaceElement)
+    expect(date).toBe('5:30')
+  })
+
 })


### PR DESCRIPTION
Implementing it with `moment-timezone` would've been prettier, but this way is simpler, more flexible and adds no extra dependencies.